### PR TITLE
Remove link to recently removed "tagging" page

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -78,5 +78,5 @@ $pool = new MemcachedCachePool($client);
 ## Features
 
 The PHP-Cache organization has built some more features on top of PSR-6. Look at our
-documentation for [tagging](tagging.md), [hierarchy](hierarchy.md) or 
-[namespace](namespace.md) for more information.
+documentation for [hierarchy](hierarchy.md) or [namespace](namespace.md) for more
+information.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -65,7 +65,7 @@ different features. Commonly used pools are:
 * Redis
 
 The steps to create a pool varies from pool to pool. Look at the pool's repository
-to see how to create it. Generally you create an connection to a cache implementation
+to see how to create it. Generally you create a connection to a cache implementation
 and then give it to the pool. See a Memcached example: 
 
 ```php


### PR DESCRIPTION
As per chat in Gitter, a PR for you. Let me know if any changes are required.
